### PR TITLE
feat: deal with complex arguments

### DIFF
--- a/includes/Parsoid/ParsoidMediaWikiParser.php
+++ b/includes/Parsoid/ParsoidMediaWikiParser.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PortableInfobox\Parsoid; 
+
+use PortableInfobox\Services\Parser\ExternalParser;
+use Wikimedia\Parsoid\Ext\ParsoidExtensionAPI;
+use Wikimedia\Parsoid\Utils\DOMCompat;
+
+class ParsoidMediaWikiParser implements ExternalParser {
+
+    private ParsoidExtensionAPI $api;
+
+    public function __construct(
+        ParsoidExtensionAPI $api
+    ) {
+        $this->api = $api;
+    }
+
+    public function parseRecursive( $wikitext ) 
+    {
+        $paramParsed = $this->api->wikitextToDOM( $wikitext, [
+			// this differs from earlier as we need the frame to be able to grab the 
+            // params the user passed - parsoid handles this internally it appears
+            'processInNewFrame' => false,
+			'parseOpts' => [ 'context' => 'inline' ]
+		], true );
+
+        // we don't want Parsoid to wrap in a span or add a typeof here, 
+        // just interested in the content
+        $res = DOMCompat::getOuterHTML( $paramParsed );
+    }
+
+    public function replaceVariables( $wikitext ) {
+		// no-op - I think handled by ->wikiTextToDOM? 
+	}
+
+    public function addImage($title, array $sizeParams): ?string
+    {
+        // no-op 
+        return '';
+    }
+}

--- a/includes/Parsoid/ParsoidMediaWikiParser.php
+++ b/includes/Parsoid/ParsoidMediaWikiParser.php
@@ -18,6 +18,10 @@ class ParsoidMediaWikiParser implements ExternalParser {
 
     public function parseRecursive( $wikitext ) 
     {
+        if ( $wikitext === null ) {
+            return null; 
+        }
+
         $paramParsed = $this->api->wikitextToDOM( $wikitext, [
 			// this differs from earlier as we need the frame to be able to grab the 
             // params the user passed - parsoid handles this internally it appears
@@ -27,7 +31,7 @@ class ParsoidMediaWikiParser implements ExternalParser {
 
         // we don't want Parsoid to wrap in a span or add a typeof here, 
         // just interested in the content
-        $res = DOMCompat::getOuterHTML( $paramParsed );
+        return DOMCompat::getOuterHTML( $paramParsed );
     }
 
     public function replaceVariables( $wikitext ) {

--- a/includes/Parsoid/ParsoidMediaWikiParser.php
+++ b/includes/Parsoid/ParsoidMediaWikiParser.php
@@ -3,12 +3,14 @@
 namespace PortableInfobox\Parsoid; 
 
 use PortableInfobox\Services\Parser\ExternalParser;
+use ReflectionClass;
 use Wikimedia\Parsoid\Ext\ParsoidExtensionAPI;
+use Wikimedia\Parsoid\Fragments\WikitextPFragment;
 use Wikimedia\Parsoid\Utils\DOMCompat;
 
 class ParsoidMediaWikiParser implements ExternalParser {
 
-    private ParsoidExtensionAPI $api;
+    public ParsoidExtensionAPI $api;
 
     public function __construct(
         ParsoidExtensionAPI $api
@@ -40,7 +42,33 @@ class ParsoidMediaWikiParser implements ExternalParser {
 
     public function addImage($title, array $sizeParams): ?string
     {
-        // no-op 
+        // no-op at present. Used to extend the image tag with specific information for the PageImages extension. 
+        // that extension relies on Parser hooks and therefore is not safe to assume that will work indefinitely.
+        // could potentially just do it for now whilst the hooks still exist, and maybe remove at a later date if
+        // PageImages is not made Parsoid-compat. 
         return '';
+    }
+
+    public function getParsoidExtensionApi(): ParsoidExtensionAPI {
+        return $this->api;
+    }
+
+    /**
+     * Extract the gallery and return the filename -> captions. PortableInfobox currently does this
+     * a lot cleaner as it piggybacks on onAfterParserFetchFileAndTitle hook to set the images into the data bag.
+     * This hook is NOT available on Parsoid, and we have no other way to get the resultant class which PortableInfobox
+     * currently relies on. So we need to fake it as best we can and hope WMF comes up with something later down
+     * the line.
+     * @param mixed $wikitext
+     * @return array an array of filenames -> captions
+     */
+    public function extractGallery( $wikitext ): array 
+    {
+        if ( $wikitext === null ) {
+            return [];
+        }
+
+        // no-op at present
+        return [];
     }
 }

--- a/includes/Parsoid/ParsoidPortableInfoboxRenderService.php
+++ b/includes/Parsoid/ParsoidPortableInfoboxRenderService.php
@@ -105,9 +105,10 @@ class ParsoidPortableInfoboxRenderService {
         array $params,
     ): array {
 
+		$externalParser = new ParsoidMediaWikiParser( $extApi );
         // same as legacy!
-        $infoboxNode = NodeFactory::newFromXML( $parsoidData, $this->paramMap ?: [] );
-		$infoboxNode->setExternalParser( new ParsoidMediaWikiParser( $extApi ) );
+        $infoboxNode = NodeFactory::newFromXML( $parsoidData, $this->paramMap ?: [], $externalParser );
+		$infoboxNode->setExternalParser( $externalParser );
         $data = $infoboxNode->getRenderData();
         $attr = $infoboxNode->getParams();
         return [ $data, $attr ];

--- a/includes/Parsoid/ParsoidPortableInfoboxRenderService.php
+++ b/includes/Parsoid/ParsoidPortableInfoboxRenderService.php
@@ -70,7 +70,7 @@ class ParsoidPortableInfoboxRenderService {
         string $parsoidData
     ): void {
         $this->buildParamMap( $extApi, $params );
-        [ $data, $attr ] = $this->prepareInfobox( $parsoidData, $this->paramMap ?: [] );
+        [ $data, $attr ] = $this->prepareInfobox( $extApi, $parsoidData, $this->paramMap ?: [] );
     
         $themes = $this->getThemes( $attr );
         $layout = $this->getLayout( $attr );
@@ -101,12 +101,14 @@ class ParsoidPortableInfoboxRenderService {
     }
 
     public function prepareInfobox(
+		ParsoidExtensionAPI $extApi,
         string $parsoidData,
         array $params,
     ): array {
 
         // same as legacy!
         $infoboxNode = NodeFactory::newFromXML( $parsoidData, $this->paramMap ?: [] );
+		$infoboxNode->setExternalParser( new ParsoidMediaWikiParser( $extApi ) );
         $data = $infoboxNode->getRenderData();
         $attr = $infoboxNode->getParams();
         return [ $data, $attr ];

--- a/includes/Parsoid/ParsoidPortableInfoboxRenderService.php
+++ b/includes/Parsoid/ParsoidPortableInfoboxRenderService.php
@@ -50,8 +50,7 @@ class ParsoidPortableInfoboxRenderService {
 		// 104 of PortableInfoboxParserTagController::class
 		foreach ( $params as $param ) {
 			if ( isset( $param->k ) && isset( $param->valueWt ) ) {
-				$htmlValue = $this->processWikitextToHtml( $extApi, $param->valueWt );
-				$this->paramMap[ $param->k ] = $htmlValue;
+				$this->paramMap[ $param->k ] = $param->valueWt;
 			}
 		}
 	}
@@ -492,34 +491,4 @@ class ParsoidPortableInfoboxRenderService {
 
 		return $horizontalGroupData;
 	}
-
-	/**
-	 * A utility function to parse wikitext to HTML which will be passed into the infobox
-	 * template
-	 * @param \Wikimedia\Parsoid\Ext\ParsoidExtensionAPI $extApi
-	 * @param string $wikitext
-	 * @return string
-	 */
-	private function processWikitextToHtml( ParsoidExtensionAPI $extApi, string $wikitext ): string {
-
-		$paramParsed = $extApi->wikitextToDOM( $wikitext, [
-			'processInNewFrame' => true,
-			'parseOpts' => [ 'context' => 'inline' ]
-		], true );
-		
-
-		$htmlContent = '';
-		// this feels really hacky?!
-		if ( $paramParsed->hasChildNodes() ) {
-
-			$tempDoc = $paramParsed->ownerDocument;
-			
-			foreach ( $paramParsed->childNodes as $childNode ) {
-				$htmlContent .= $tempDoc->saveHTML( $childNode );
-			}
-		}
-		
-		return $htmlContent;
-	}
-
 }

--- a/includes/Parsoid/ParsoidPortableInfoboxRenderService.php
+++ b/includes/Parsoid/ParsoidPortableInfoboxRenderService.php
@@ -18,7 +18,6 @@ class ParsoidPortableInfoboxRenderService {
 	public const DEFAULT_THEME_NAME = 'default';
 	public const INFOBOX_THEME_PREFIX = 'pi-theme-';
 
-	private const PARSER_TAG_NAME = 'infobox';
 	private const DEFAULT_LAYOUT_NAME = 'default';
 	private const INFOBOX_LAYOUT_PREFIX = 'pi-layout-';
 	private const INFOBOX_TYPE_PREFIX = 'pi-type-';
@@ -26,6 +25,9 @@ class ParsoidPortableInfoboxRenderService {
 	private const ACCENT_COLOR_TEXT = 'accent-color-text';
 	private const ERR_UNIMPLEMENTEDNODE = 'portable-infobox-unimplemented-infobox-tag';
 	private const ERR_UNSUPPORTEDATTR = 'portable-infobox-xml-parse-error-infobox-tag-attribute-unsupported';
+
+	public const DEFAULT_DESKTOP_INFOBOX_WIDTH = 270;
+	public const DEFAULT_DESKTOP_THUMBNAIL_WIDTH = 350;
 
 	private ?InfoboxParamsValidator $infoboxParamsValidator = null;
 

--- a/includes/Services/Parser/Nodes/Node.php
+++ b/includes/Services/Parser/Nodes/Node.php
@@ -150,8 +150,8 @@ class Node {
 		if ( !isset( $this->children ) ) {
 			$this->children = [];
 			foreach ( $this->xmlNode as $child ) {
-				$this->children[] = NodeFactory::newFromSimpleXml( $child, $this->infoboxData )
-					->setExternalParser( $this->externalParser );
+				$this->children[] = NodeFactory::newFromSimpleXml( $child, $this->infoboxData, $this->getExternalParser() )
+					->setExternalParser( $this->getExternalParser() );
 			}
 		}
 

--- a/includes/Services/Parser/Nodes/NodeFactory.php
+++ b/includes/Services/Parser/Nodes/NodeFactory.php
@@ -28,11 +28,14 @@ class NodeFactory {
 		// a bit messed up, but we want to do some special stuff here with images
 		// that differs from the legacy implementation (which also calls out to Parser.php)
 		// so lets load a different class if we have an image
-		if ( ( $tagType === 'image' ) && 
-            $externalParser instanceof ParsoidMediaWikiParser ) {
-            return new ParsoidMediaNode( $xmlNode, $data );
-        }
-
+		if ( $externalParser instanceof ParsoidMediaWikiParser ) {
+			if ( $tagType === 'image' ) {
+				return new ParsoidImageNode( $xmlNode, $data );
+			} elseif ( $tagType === 'media' ) {
+				return new ParsoidMediaNode( $xmlNode, $data );
+			}
+		}
+		
 		$className = Node::class . mb_convert_case( mb_strtolower( $tagType ), MB_CASE_TITLE );
 		if ( class_exists( $className ) ) {
 			/* @var $instance Node */

--- a/includes/Services/Parser/Nodes/NodeFactory.php
+++ b/includes/Services/Parser/Nodes/NodeFactory.php
@@ -2,17 +2,18 @@
 
 namespace PortableInfobox\Services\Parser\Nodes;
 
+use PortableInfobox\Parsoid\ParsoidMediaWikiParser;
 use PortableInfobox\Services\Parser\XmlParser;
 use SimpleXMLElement;
 
 class NodeFactory {
 
-	public static function newFromXML( $text, array $data = [] ) {
-		return self::getInstance( XmlParser::parseXmlString( $text ), $data );
+	public static function newFromXML( $text, array $data = [], $externalParser = null ) {
+		return self::getInstance( XmlParser::parseXmlString( $text ), $data, $externalParser );
 	}
 
-	public static function newFromSimpleXml( SimpleXMLElement $xmlNode, array $data = [] ) {
-		return self::getInstance( $xmlNode, $data );
+	public static function newFromSimpleXml( SimpleXMLElement $xmlNode, array $data = [], $externalParser = null ) {
+		return self::getInstance( $xmlNode, $data, $externalParser );
 	}
 
 	/**
@@ -21,8 +22,17 @@ class NodeFactory {
 	 *
 	 * @return Node|NodeUnimplemented
 	 */
-	protected static function getInstance( SimpleXMLElement $xmlNode, array $data ) {
+	protected static function getInstance( SimpleXMLElement $xmlNode, array $data, $externalParser ) {
 		$tagType = $xmlNode->getName();
+
+		// a bit messed up, but we want to do some special stuff here with images
+		// that differs from the legacy implementation (which also calls out to Parser.php)
+		// so lets load a different class if we have an image
+		if ( ( $tagType === 'image' ) && 
+            $externalParser instanceof ParsoidMediaWikiParser ) {
+            return new ParsoidMediaNode( $xmlNode, $data );
+        }
+
 		$className = Node::class . mb_convert_case( mb_strtolower( $tagType ), MB_CASE_TITLE );
 		if ( class_exists( $className ) ) {
 			/* @var $instance Node */

--- a/includes/Services/Parser/Nodes/ParsoidImageNode.php
+++ b/includes/Services/Parser/Nodes/ParsoidImageNode.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PortableInfobox\Services\Parser\Nodes;
+
+class ParsoidImageNode extends ParsoidMediaNode {
+	/*
+	 * @return string
+	 */
+	public function getType() {
+		return 'media';
+	}
+
+	/*
+	 * @return bool
+	 */
+	protected function allowImage() {
+		return true;
+	}
+
+	/*
+	 * @return bool
+	 */
+	protected function allowAudio() {
+		return false;
+	}
+}

--- a/includes/Services/Parser/Nodes/ParsoidMediaNode.php
+++ b/includes/Services/Parser/Nodes/ParsoidMediaNode.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace PortableInfobox\Services\Parser\Nodes;
+
+use PortableInfobox\Services\Helpers\PortableInfoboxImagesHelper;
+
+class ParsoidMediaNode extends Node {
+
+    private ?PortableInfoboxImagesHelper $helper;
+
+    /**
+     * Return the data for the image
+     * return array
+     */
+    public function getData(): array {
+		if ( !isset( $this->data ) ) {
+			$this->data = [];
+
+			// value passed to source parameter (or default)
+			$value = $this->getRawValueWithDefault( $this->xmlNode );
+            if ( $this->containsTabberOrGallery( $value ) ) {
+				$this->data = $this->getImagesData( $value );
+			} else {
+				// $this->data = [ $this->getImageData(
+				// 	$value,
+				// 	$this->getValueWithDefault( $this->xmlNode->{self::ALT_TAG_NAME} ),
+				// 	$this->getValueWithDefault( $this->xmlNode->{self::CAPTION_TAG_NAME} )
+				// ) ];
+			}
+        }
+		return $this->data;
+	}
+
+    /**
+     * Checks if string contains raw <gallery> or <tabber> tags using a hacky regex. With the legacy Parser,
+     * by the time this function runs in NodeMedia::class, the intial parse has already replaced the $str with a strip marker
+     * we are not in such environment and we will receieve the raw wikitext passed by the user
+     * @param string $value wikitext passed in the parameter
+     * @return bool
+     */
+    private function containsTabberOrGallery( string $value ): bool {
+        // <gallery></gallery>
+        if ( preg_match( '/<gallery\b[^>]*>/i', $value ?? '' ) ) {
+            return true;
+        }
+        
+        // <tabber></tabber>
+        if ( preg_match( '/<tabber\b[^>]*>/i', $value ?? '' ) ) {
+            return true;
+        }
+        
+        return false;
+    }
+
+    /**
+     * Get the data about the image (or images if tabber/gallery) and return it as an array
+     * @TODO: revisit this later, see comment on ParsoidMediaWikiParser::extractGallery for why this
+     * is a bad idea - but it works
+     * @param string $value the wikitext gallery
+     * @param mixed $value
+     */
+    private function getImagesData( string $value ) {
+		$helper = $this->getImageHelper();
+		$data = [];
+        $parser = $this->getExternalParser();
+        $images = $parser->extractGallery( $value );
+		
+        // no-op right now
+        return [];
+	}
+
+    /**
+     * Get an instance of the PortableInfoboxImageHelper
+     * @return PortableInfoboxImagesHelper
+     */
+    protected function getImageHelper() {
+		if ( !isset( $this->helper ) ) {
+			$this->helper = new PortableInfoboxImagesHelper();
+		}
+		return $this->helper;
+	}
+}

--- a/includes/Services/Parser/Nodes/ParsoidMediaNode.php
+++ b/includes/Services/Parser/Nodes/ParsoidMediaNode.php
@@ -2,11 +2,19 @@
 
 namespace PortableInfobox\Services\Parser\Nodes;
 
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use PortableInfobox\Parsoid\ParsoidPortableInfoboxRenderService;
+use PortableInfobox\Services\Helpers\FileNamespaceSanitizeHelper;
 use PortableInfobox\Services\Helpers\PortableInfoboxImagesHelper;
 
 class ParsoidMediaNode extends Node {
 
     private ?PortableInfoboxImagesHelper $helper;
+
+    private const ALLOWIMAGE_ATTR_NAME = 'image';
+	private const ALLOWVIDEO_ATTR_NAME = 'video';
+	private const ALLOWAUDIO_ATTR_NAME = 'audio';
 
     /**
      * Return the data for the image
@@ -63,10 +71,82 @@ class ParsoidMediaNode extends Node {
 		$helper = $this->getImageHelper();
 		$data = [];
         $parser = $this->getExternalParser();
-        $images = $parser->extractGallery( $value );
-		
-        // no-op right now
-        return [];
+        $items = $parser->extractGallery( $value );
+		// @TODO: do tabbers also 
+        foreach ( $items as $item ) {
+			$mediaItem = $this->getImageData( $item['title'], $item['label'], $item['label'] );
+			if ( (bool)$mediaItem ) {
+				$data[] = $mediaItem;
+			}
+		}
+
+        return count( $data ) > 1 ? $helper->extendImageCollectionData( $data ) : $data;
+	}
+
+    private function getImageData( $title, $alt, $caption ) {
+		$helper = $this->getImageHelper();
+		$titleObj = $title instanceof Title ? $title : $this->getImageAsTitleObject( $title );
+		$fileObj = $helper->getFile( $titleObj );
+
+		if ( !isset( $fileObj ) || !$this->isTypeAllowed( $fileObj->getMediaType() ) ) {
+			return [];
+		}
+
+		$mediatype = $fileObj->getMediaType();
+		$image = [
+			'url' => $this->resolveImageUrl( $fileObj, $titleObj ),
+			'name' => $titleObj ? $titleObj->getText() : '',
+			'alt' => $alt ?? ( $titleObj ? $titleObj->getText() : null ),
+			'caption' => $caption ?: null,
+			'isImage' => in_array( $mediatype, [ MEDIATYPE_BITMAP, MEDIATYPE_DRAWING ] ),
+			'isVideo' => $mediatype === MEDIATYPE_VIDEO,
+			'isAudio' => $mediatype === MEDIATYPE_AUDIO,
+			'source' => $this->getPrimarySource(),
+			'item-name' => $this->getItemName(),
+			'htmlAfter' => null,
+		];
+
+		if ( $image['isImage'] ) {
+			$image = array_merge( $image, $helper->extendImageData(
+				$fileObj,
+				ParsoidPortableInfoboxRenderService::DEFAULT_DESKTOP_THUMBNAIL_WIDTH,
+				ParsoidPortableInfoboxRenderService::DEFAULT_DESKTOP_INFOBOX_WIDTH
+			) );
+		}
+
+		return $image;
+	}
+
+    /**
+     * Get the image as a title object
+     * @param $imageName the image name 
+     * @return Title
+     */
+    private function getImageAsTitleObject( $imageName ): Title {
+		$contLang = MediaWikiServices::getInstance()->getContentLanguage();
+
+		$title = Title::makeTitleSafe(
+			NS_FILE,
+			FileNamespaceSanitizeHelper::getInstance()->sanitizeImageFileName( $imageName, $contLang )
+		);
+
+		return $title;
+	}
+
+    /**
+	 * Returns image url for given image title
+	 * @param File|null $file
+	 * @param Title|null $title
+	 * @return string url or '' if image doesn't exist
+	 */
+	public function resolveImageUrl( $file, $title ) {
+		global $wgPortableInfoboxUseFileDescriptionPage;
+
+		if ( $wgPortableInfoboxUseFileDescriptionPage && $title ) {
+			return $title->getLocalURL();
+		}
+
+		return $file ? $file->getUrl() : '';
 	}
 
     /**
@@ -78,5 +158,65 @@ class ParsoidMediaNode extends Node {
 			$this->helper = new PortableInfoboxImagesHelper();
 		}
 		return $this->helper;
+	}
+
+    /**
+	 * Checks if file media type is allowed
+	 * @param string $type
+	 * @return bool
+	 */
+	private function isTypeAllowed( $type ) {
+		switch ( $type ) {
+			case MEDIATYPE_BITMAP:
+			case MEDIATYPE_DRAWING:
+				return $this->allowImage();
+			case MEDIATYPE_VIDEO:
+				return $this->allowVideo();
+			case MEDIATYPE_AUDIO:
+				return $this->allowAudio();
+			default:
+				return false;
+		}
+	}
+
+    /**
+	 * @return bool
+	 */
+	protected function allowImage() {
+		$attr = $this->getXmlAttribute( $this->xmlNode, self::ALLOWIMAGE_ATTR_NAME );
+
+		return !( isset( $attr ) && strtolower( $attr ) === 'false' );
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function allowVideo() {
+		$attr = $this->getXmlAttribute( $this->xmlNode, self::ALLOWVIDEO_ATTR_NAME );
+
+		return !( isset( $attr ) && strtolower( $attr ) === 'false' );
+	}
+
+	/*
+	 * @return bool
+	 */
+	protected function allowAudio() {
+		$attr = $this->getXmlAttribute( $this->xmlNode, self::ALLOWAUDIO_ATTR_NAME );
+
+		return !( isset( $attr ) && strtolower( $attr ) === 'false' );
+	}
+
+    public function isEmpty() {
+		$data = $this->getData();
+		foreach ( $data as $dataItem ) {
+			if ( !empty( $dataItem['url'] ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public function getType() {
+		return 'media';
 	}
 }

--- a/includes/Services/Parser/Nodes/ParsoidMediaNode.php
+++ b/includes/Services/Parser/Nodes/ParsoidMediaNode.php
@@ -15,6 +15,8 @@ class ParsoidMediaNode extends Node {
     private const ALLOWIMAGE_ATTR_NAME = 'image';
 	private const ALLOWVIDEO_ATTR_NAME = 'video';
 	private const ALLOWAUDIO_ATTR_NAME = 'audio';
+	private const ALT_TAG_NAME = 'alt';
+	private const CAPTION_TAG_NAME = 'caption';
 
     /**
      * Return the data for the image
@@ -29,11 +31,11 @@ class ParsoidMediaNode extends Node {
             if ( $this->containsTabberOrGallery( $value ) ) {
 				$this->data = $this->getImagesData( $value );
 			} else {
-				// $this->data = [ $this->getImageData(
-				// 	$value,
-				// 	$this->getValueWithDefault( $this->xmlNode->{self::ALT_TAG_NAME} ),
-				// 	$this->getValueWithDefault( $this->xmlNode->{self::CAPTION_TAG_NAME} )
-				// ) ];
+				$this->data = [ $this->getImageData(
+					$value,
+					$this->getValueWithDefault( $this->xmlNode->{self::ALT_TAG_NAME} ),
+					$this->getValueWithDefault( $this->xmlNode->{self::CAPTION_TAG_NAME} )
+				) ];
 			}
         }
 		return $this->data;


### PR DESCRIPTION
Deals with complex arguments specifically:
- `<gallery>` tags in image parameters. 
- Parses the template such as `<label>{{#if....}}</label>` to get the resultant HTML. 

Some other minor and complex stuff - this is getting a bit messy and needs refactoring once it all works properly.